### PR TITLE
Implement summary-based title suggestions

### DIFF
--- a/utils/api.ts
+++ b/utils/api.ts
@@ -4,7 +4,7 @@ const createUrl = (path) =>{
 
 
 export const askQuestion = async (question) => {
-    const res = await fetch( new Request( createUrl('/api/question'), {
+    const res = await fetch( new Request( createUrl('/api/book'), {
         method: 'POST',
         body: JSON.stringify({question}),
     }));


### PR DESCRIPTION
## Summary
- adjust API helper to hit `/api/book`
- update chat flow in `ChatScreen.jsx`
  - first capture book type then prompt for summary
  - send summary to the server to generate title suggestions
  - reset chat state properly

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68626f2f844c8324a6ccfb07030f1176