### PR TITLE
Add summary saving API and integrate

### DIFF
--- a/components/ChatScreen.jsx
+++ b/components/ChatScreen.jsx
@@ -4,9 +4,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import '../stylesheets/style.css';
 import { Icon } from '@iconify/react';
 
-import { askQuestion, saveTitle } from '../utils/api';
-
-import { askQuestion } from '../utils/api';
+import { askQuestion, saveTitle, createBook } from '../utils/api';
 
 
 export default function ChatScreen() {
@@ -26,7 +24,7 @@ export default function ChatScreen() {
   const [selectedChapter, setSelectedChapter] = useState('');
   const [selectedBookType, setSelectedBookType] = useState('');
   const [chapterCount, setChapterCount] = useState(null);
-  const [bookUUID, setBookUUID] = useState('123e4567-e89b-12d3-a456-426614174000'); // Example UUID
+  const [bookId, setBookId] = useState(null);
   const [titleOptions, setTitleOptions] = useState([]);
 
 
@@ -80,6 +78,8 @@ export default function ChatScreen() {
 
       try {
 
+        const created = await createBook(currentInput);
+        setBookId(created._id);
         const answer = await askQuestion(
           `Provide 10 book title suggestions with subtitles based on the following summary:\n${currentInput}`
         );
@@ -116,15 +116,6 @@ export default function ChatScreen() {
           prev.map((m) =>
             m.id === loadingId ? { id: loadingId, sender: 'bot', text: 'Failed to fetch suggestions.' } : m
           )
-
-        const answer = await askQuestion(`Provide 10 book title suggestions with subtitles based on the following summary:\n${currentInput}`);
-        setMessages((prev) =>
-          prev.map((m) => (m.id === loadingId ? { id: loadingId, sender: 'bot', text: answer } : m))
-        );
-      } catch (e) {
-        setMessages((prev) =>
-          prev.map((m) => (m.id === loadingId ? { id: loadingId, sender: 'bot', text: 'Failed to fetch suggestions.' } : m))
-
         );
       }
       setStep('title');
@@ -193,7 +184,7 @@ export default function ChatScreen() {
       { id: Date.now(), sender: 'user', text: `I like "${title}"` },
     ]);
     try {
-      await saveTitle(bookUUID, title);
+      await saveTitle(bookId, title);
     } catch (e) {
       console.error(e);
     }
@@ -309,6 +300,7 @@ export default function ChatScreen() {
     setSelectedChapter('');
     setBookType('');
     setChapterCount(null);
+    setBookId(null);
 
   };
   const formatMessageText = (text) => {
@@ -458,7 +450,7 @@ export default function ChatScreen() {
         </div>
         {/* Top Notch-like Title Bar */}
         <div className="floating-title-bar">
-          Your Book uuid: <strong>{bookUUID}</strong>
+          Your Book id: <strong>{bookId}</strong>
         </div>
 
 

--- a/src/app/api/book/summary/route.ts
+++ b/src/app/api/book/summary/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+import { connectToDatabase } from "../../../../../utils/db";
+import { Book } from "../../../../../models/book";
+
+export const POST = async (req: Request) => {
+    const { summary } = await req.json();
+    if (!summary) {
+        return NextResponse.json({ error: "Summary is required" }, { status: 400 });
+    }
+
+    await connectToDatabase();
+    const book = await Book.create({ summary, status: 'draft' });
+    return NextResponse.json({ data: book });
+};

--- a/utils/api.ts
+++ b/utils/api.ts
@@ -17,6 +17,19 @@ export const askQuestion = async (question) => {
 
 }
 
+export const createBook = async (summary) => {
+    const res = await fetch(new Request(createUrl('/api/book/summary'), {
+        method: 'POST',
+        body: JSON.stringify({ summary }),
+    }));
+    if(res.ok) {
+        const data = await res.json();
+        return data.data;
+    } else {
+        throw new Error('Failed to create book');
+    }
+}
+
 
 export const saveTitle = async (bookId, title) => {
     const res = await fetch(new Request(createUrl('/api/book/title'), {


### PR DESCRIPTION
## Summary
- create `/api/book/summary` endpoint for saving summaries
- expose `createBook` helper in `utils/api.ts`
- store returned `bookId` when user submits a summary
- reset id when clearing chat and show id in UI

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68627bf937208324973f4f79e5a23bd5