### PR TITLE
Add dynamic chapter hints and keypoint handling

### DIFF
--- a/components/ChatScreen.jsx
+++ b/components/ChatScreen.jsx
@@ -106,7 +106,7 @@ export default function ChatScreen() {
           .split(/\n|\r/)
           .map((t) => t.trim())
           .filter((t) => /^\d+\./.test(t))
-          .map((t) => t.replace(/^\d+\.\s*/, ''));
+          .map((t) => t.replace(/^\d+\.\s*/, '').replace(/\*\*/g, '').trim());
         setTitleOptions(titles);
         setMessages((prev) =>
           prev.map((m) =>
@@ -144,7 +144,7 @@ export default function ChatScreen() {
             {
               id: generateId(),
               sender: 'bot',
-              text: `How many chapters do you want in your ${selectedBookType}?`,
+              text: `How many chapters do you want in your ${selectedBookType}? Usually this type has ${getChapterRange()} chapters.`,
             },
           ]);
           setStep('chapters');
@@ -191,6 +191,7 @@ export default function ChatScreen() {
                   text: `Awesome! Now, please enter ${getRequiredKeyPoints()} key points you want to cover in your book.`,
                 },
               ]);
+              setKeyPoints(getInitialKeyPoints());
               setStep('keypoints');
             } else {
               setIsGenerating(true);
@@ -200,15 +201,26 @@ export default function ChatScreen() {
           }
   };
 
-  const getRequiredKeyPoints = () => {
+const getRequiredKeyPoints = () => {
   if (bookType === 'Ebook') return 8;
   if (bookType === 'Short Book') return 16;
   return 20; // Full Length Book
 };
 
+  const getChapterRange = () => {
+    if (bookType === 'Ebook') return '4-6';
+    if (bookType === 'Short Book') return '5-10';
+    return '10-12';
+  };
+
+  const getInitialKeyPoints = () => {
+    return Array(Math.max(3, getRequiredKeyPoints())).fill('');
+  };
+
 
   const handleTitleSelect = async (title , bookIdArg) => {
-    setSelectedTitle(title);
+    const cleanTitle = title.replace(/\*\*/g, '').trim();
+    setSelectedTitle(cleanTitle);
     if (!bookIdArg) {
       console.error("Cannot save title: bookId is null");
       return;
@@ -231,7 +243,7 @@ export default function ChatScreen() {
       {
         id: generateId(),
         sender: 'bot',
-        text: `How many chapters do you want in your ${selectedBookType}?`,
+        text: `How many chapters do you want in your ${selectedBookType}? Usually this type has ${getChapterRange()} chapters.`,
       },
     ]);
     setStep('chapters');
@@ -240,8 +252,9 @@ export default function ChatScreen() {
   };
 
   const handleChapterSelect = (chapterName) => {
-    setSelectedChapter(chapterName);
-    setInput(chapterName);
+    const cleanName = chapterName.replace(/\*\*/g, '').trim();
+    setSelectedChapter(cleanName);
+    setInput(cleanName);
     inputRef.current?.focus();
   };
 
@@ -259,7 +272,7 @@ export default function ChatScreen() {
       .split(/\n|\r/)
       .map((t) => t.trim())
       .filter((t) => /^\d+\./.test(t))
-      .map((t) => t.replace(/^\d+\.\s*/, ''));
+      .map((t) => t.replace(/^\d+\.\s*/, '').replace(/\*\*/g, '').trim());
     return titles;
   };
 
@@ -308,6 +321,8 @@ export default function ChatScreen() {
           },
         ]);
         setCurrentChapter(next);
+        setHasKeyPoints(false);
+        setKeyPoints(getInitialKeyPoints());
         setStep('chapterTitle');
       } else {
         setMessages((prev) => [
@@ -386,7 +401,7 @@ export default function ChatScreen() {
     ]);
      setInput('');
     setStep('bookType');
-    setKeyPoints(['', '', '']);
+    setKeyPoints(getInitialKeyPoints());
     setSelectedBookType('');
     setSelectedTitle('');
     setSelectedChapter('');

--- a/src/app/api/book/chapter/route.ts
+++ b/src/app/api/book/chapter/route.ts
@@ -19,7 +19,9 @@ export const POST = async (req: Request) => {
   book.status = "generating";
   await book.save();
 
-  const prompt = `You are a professional book writer. Write chapter ${chapterIndex} titled "${chapterTitle}" for the ${bookType} \"${title}\". Divide the chapter into 4 parts, each beginning with a short subheading. Base it on the following summary and key points.\nSummary: ${summary}\nKey points: ${keyPoints.join("; ")}`;
+  const wordsPerPart =
+    bookType === 'Ebook' ? 700 : bookType === 'Short Book' ? 100 : 1500;
+  const prompt = `You are a professional book writer. Write chapter ${chapterIndex} titled "${chapterTitle}" for the ${bookType} \"${title}\". Divide the chapter into 4 parts, each about ${wordsPerPart} words and beginning with a short subheading. Base it on the following summary and key points.\nSummary: ${summary}\nKey points: ${keyPoints.join("; ")}`;
 
   const model = new ChatOpenAI({
     modelName: "gpt-4o-mini",

--- a/src/app/api/book/generate/route.ts
+++ b/src/app/api/book/generate/route.ts
@@ -21,7 +21,9 @@ export const POST = async (req: Request) => {
   book.chapterCount = chapterCount;
   await book.save();
 
-  const prompt = `You are a professional book writer. Write a ${bookType} titled "${title}" based on the following summary and key points. The book must have ${chapterCount} chapters. \nSummary: ${summary}\nKey points: ${keyPoints.join("; ")}`;
+  const wordsPerPart =
+    bookType === 'Ebook' ? 700 : bookType === 'Short Book' ? 100 : 1500;
+  const prompt = `You are a professional book writer. Write a ${bookType} titled "${title}" based on the following summary and key points. The book must have ${chapterCount} chapters with each part about ${wordsPerPart} words. \nSummary: ${summary}\nKey points: ${keyPoints.join("; ")}`;
 
   const model = new ChatOpenAI({
     modelName: "gpt-4o-mini",


### PR DESCRIPTION
## Summary
- remove Markdown markers from title and chapter suggestions
- show typical chapter range before asking for chapter count
- request new key points for each chapter
- reset key points between chapters
- enforce word counts per book type in generation prompts

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6862f139f9b08324a6b0bfef3b64cd6d