### PR TITLE
Improve old book button & mobile chat

### DIFF
--- a/components/ChatScreen.jsx
+++ b/components/ChatScreen.jsx
@@ -9,7 +9,7 @@ import { askQuestion, saveTitle, createBook, generateChapter } from '../utils/ap
 const generateId = () => `${Date.now()}-${Math.random().toString(16).slice(2)}`;
 
 
-export default function ChatScreen() {
+export default function ChatScreen({ initialBookId = null }) {
   const bottomRef = useRef(null);
   const inputRef = useRef(null);
   const keyPointRefs = useRef([]);
@@ -34,6 +34,17 @@ export default function ChatScreen() {
   const [hasKeyPoints, setHasKeyPoints] = useState(false);
   const [isGenerating, setIsGenerating] = useState(false);
   const [isMultiline, setIsMultiline] = useState(false);
+
+  // Load stored chat when an initial book id is provided
+  useEffect(() => {
+    if (initialBookId) {
+      setBookId(initialBookId);
+      const stored = localStorage.getItem(`chat_${initialBookId}`);
+      if (stored) {
+        setMessages(JSON.parse(stored));
+      }
+    }
+  }, [initialBookId]);
 
 
   const handleInputChange = (e) => {

--- a/src/app/home/[id]/page.jsx
+++ b/src/app/home/[id]/page.jsx
@@ -1,0 +1,17 @@
+'use client';
+import React from 'react';
+import Sidebar from '../../../../components/Sidebar';
+import '../../../../stylesheets/style.css';
+import ChatScreen from '../../../../components/ChatScreen';
+import { useParams } from 'next/navigation';
+
+export default function HomeBookPage() {
+  const params = useParams();
+  const { id } = params;
+  return (
+    <div className="mainBg">
+      <Sidebar />
+      <ChatScreen initialBookId={id} />
+    </div>
+  );
+}

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -16,21 +16,21 @@ export default function Home() {
         <h2 className="mb-4 fw-bold" style={{ color: '#f4845f' }}>📚 Logo</h2>
         <h1 className={styles.title}>Let&apos;s start writing your new book</h1>
 
-         {showInput && (
-          <div style={{textAlign: 'center', display: 'flex', flexDirection: 'column', alignItems: 'start'}}>
+        {showInput && (
+          <div className={styles.oldBookContainer}>
             <input
               type="text"
-              placeholder="Enter Book UUID"
+              placeholder="Enter Book ID"
               value={uuid}
               onChange={(e) => setUuid(e.target.value)}
-              style={{ padding: '0.5rem', width: '300px', borderRadius: '8px' }}
+              className={styles.oldBookInput}
             />
             {uuid && (
-                <Link href={`/home/${uuid}`} >
-              <button className={styles.secondary} style={{ marginTop: '1rem', height: '50px' }}>
+              <Link href={`/home/${uuid}`}>
+                <button className={`${styles.secondary} ${styles.continueBtn}`}>
                   Continue with this Book
-              </button>
-                </Link>
+                </button>
+              </Link>
             )}
           </div>
         )}

--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -177,6 +177,37 @@ a.primary {
   }
 }
 
+.oldBookContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  animation: fadeIn 0.3s ease-in-out;
+}
+
+.oldBookInput {
+  padding: 0.5rem;
+  width: 300px;
+  border-radius: 8px;
+  border: 1px solid #ccc;
+}
+
+.continueBtn {
+  margin-top: 1rem;
+  height: 50px;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(-5px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 @media (prefers-color-scheme: dark) {
   .logo {
     filter: invert();

--- a/stylesheets/style.css
+++ b/stylesheets/style.css
@@ -60,7 +60,8 @@
 }
 
 .chatInputBg{
-    width: 500px;
+    width: 100%;
+    max-width: 500px;
     display: flex;
     justify-content: center;
     align-items: center;
@@ -238,7 +239,19 @@ width: 80%;
   z-index: 9999; /* Make sure it stays on top */
   font-size: 17px;
   opacity: 0.95;
-  pointer-events: none; 
-  
+  pointer-events: none;
+
+}
+
+@media (max-width: 600px) {
+  .messages {
+    width: 95%;
+  }
+  .chatInputBg {
+    width: 95%;
+  }
+  .keypointBg {
+    width: 95%;
+  }
 }
 


### PR DESCRIPTION
## Summary
- add new /home/[id] route to load chat by ID
- make chat screen accept initial book id
- enhance mobile styles for chat UI
- style old book input interaction

## Testing
- `npm run lint`
- `npm run build` *(fails: MONGODB_URI not defined)*

------
https://chatgpt.com/codex/tasks/task_e_686301a5375c8324b0be6bf2e5b95d80