### PR TITLE
Add chapter outline generation feature

### DIFF
--- a/src/app/api/book/route.ts
+++ b/src/app/api/book/route.ts
@@ -1,10 +1,8 @@
 import { qa } from "../../../../utils/ai";
 import { NextResponse } from "next/server";
 
-export const POST = async (request) =>{
-    const {question} = await request.json();
-
-    const answer = await qa(question);
-
-    return NextResponse.json({data: answer});
-} 
+export const POST = async (request) => {
+  const { question } = await request.json();
+  const answer = await qa(question);
+  return NextResponse.json({ data: answer });
+};


### PR DESCRIPTION
## Summary
- overhaul chapter flow to generate full outline before writing
- hide input when outline options displayed
- add outline decision logic and state persistence
- clean up QA API route file

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6863cd087ecc8324ab37be283f080609