### PR TITLE
Enhance old chat loading

### DIFF
--- a/components/Sidebar.jsx
+++ b/components/Sidebar.jsx
@@ -4,11 +4,13 @@ import React, { useState, useEffect } from "react";
 import { Icon } from "@iconify/react";
 import "../stylesheets/style.css";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 
 
 export default function Sidebar() {
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [titles, setTitles] = useState([]);
+  const router = useRouter();
 
   const toggleSidebar = () => setIsCollapsed(!isCollapsed);
 
@@ -24,7 +26,7 @@ export default function Sidebar() {
   }, []);
 
   const handleSelect = (id) => {
-    window.dispatchEvent(new CustomEvent("loadChat", { detail: { bookId: id } }));
+    router.push(`/home/${id}`);
   };
 
   const clearAll = () => {

--- a/stylesheets/style.css
+++ b/stylesheets/style.css
@@ -254,3 +254,34 @@ width: 80%;
   }
 }
 
+.loading-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 9999;
+}
+
+.loading-spinner {
+  border: 4px solid #f3f3f3;
+  border-top: 4px solid #f4845f;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+


### PR DESCRIPTION
## Summary
- add loading spinner when restoring saved chats
- keep outlines visible after restoring by injecting message
- save loaded titles to local storage
- update sidebar links to open chats via routing
- style spinner animation

## Testing
- `npm run lint`
- `MONGODB_URI='mongodb://localhost:27017/test' npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6863de47d9d48324893dd9f8e5da459a