### PR TITLE
Fix outline retrieval

### DIFF
--- a/components/ChatScreen.jsx
+++ b/components/ChatScreen.jsx
@@ -60,7 +60,7 @@ export default function ChatScreen({ initialBookId = null }) {
           if (Array.isArray(stored.keyPoints)) setKeyPoints(stored.keyPoints);
           if (typeof stored.hasKeyPoints === 'boolean') setHasKeyPoints(stored.hasKeyPoints);
           if (Array.isArray(stored.outline)) setOutline(stored.outline);
-          if (stored.step === 'outline' && Array.isArray(stored.outline) && stored.outline.length > 0) {
+          if (Array.isArray(stored.outline) && stored.outline.length > 0) {
             restoredMessages = [
               ...restoredMessages,
               {
@@ -188,7 +188,7 @@ export default function ChatScreen({ initialBookId = null }) {
           if (Array.isArray(stored.keyPoints)) setKeyPoints(stored.keyPoints);
           if (typeof stored.hasKeyPoints === 'boolean') setHasKeyPoints(stored.hasKeyPoints);
           if (Array.isArray(stored.outline)) setOutline(stored.outline);
-          if (stored.step === 'outline' && Array.isArray(stored.outline) && stored.outline.length > 0) {
+          if (Array.isArray(stored.outline) && stored.outline.length > 0) {
             restoredMessages = [
               ...restoredMessages,
               {


### PR DESCRIPTION
## Summary
- ensure stored outlines render on chat reload

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6863e185864c832495724b77d20c0a9c