### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -192,6 +192,7 @@ a.primary {
   }
 }
 
+
 .oldBookContainer {
   display: flex;
   align-items: center;
@@ -222,6 +223,34 @@ a.primary {
   to {
     opacity: 1;
     transform: translateY(0);
+  }
+}
+
+@media (max-width: 768px) {
+  .oldBookContainer {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .oldBookInput {
+    width: 100%;
+    min-width: 0;
+  }
+  .continueBtn {
+    width: 100%;
+    margin-top: 0.5rem;
+  }
+  .ctas a {
+    width: 100%;
+    justify-content: center;
+  }
+}
+
+@media (max-width: 480px) {
+  .title {
+    font-size: 1.5rem;
+  }
+  .page {
+    padding: 24px;
   }
 }
 

--- a/stylesheets/style.css
+++ b/stylesheets/style.css
@@ -254,6 +254,36 @@ width: 80%;
   }
 }
 
+@media (max-width: 768px) {
+  .mainBg {
+    flex-direction: column;
+  }
+  .sidebar {
+    width: 100%;
+    height: auto;
+    margin-left: 0;
+    flex-direction: row;
+    padding: 10px;
+  }
+  .sidebar.collapsed {
+    width: 100%;
+  }
+  .chatScreen {
+    margin-top: 1rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .btn-1 {
+    width: 100%;
+  }
+  .messages,
+  .chatInputBg,
+  .keypointBg {
+    width: 100%;
+  }
+}
+
 .loading-overlay {
   position: fixed;
   top: 0;


### PR DESCRIPTION
## Summary
- add new responsive media queries for the chat sidebar and home page
- tweak landing page styles for small screens

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6863e2a82d508324a5c9e1fdd12b2c3d