### PR TITLE
Fix chat resume logic

### DIFF
--- a/components/ChatScreen.jsx
+++ b/components/ChatScreen.jsx
@@ -60,7 +60,11 @@ export default function ChatScreen({ initialBookId = null }) {
           if (Array.isArray(stored.keyPoints)) setKeyPoints(stored.keyPoints);
           if (typeof stored.hasKeyPoints === 'boolean') setHasKeyPoints(stored.hasKeyPoints);
           if (Array.isArray(stored.outline)) setOutline(stored.outline);
-          if (Array.isArray(stored.outline) && stored.outline.length > 0) {
+          if (
+            stored.step === 'outline' &&
+            Array.isArray(stored.outline) &&
+            stored.outline.length > 0
+          ) {
             restoredMessages = [
               ...restoredMessages,
               {
@@ -188,7 +192,11 @@ export default function ChatScreen({ initialBookId = null }) {
           if (Array.isArray(stored.keyPoints)) setKeyPoints(stored.keyPoints);
           if (typeof stored.hasKeyPoints === 'boolean') setHasKeyPoints(stored.hasKeyPoints);
           if (Array.isArray(stored.outline)) setOutline(stored.outline);
-          if (Array.isArray(stored.outline) && stored.outline.length > 0) {
+          if (
+            stored.step === 'outline' &&
+            Array.isArray(stored.outline) &&
+            stored.outline.length > 0
+          ) {
             restoredMessages = [
               ...restoredMessages,
               {

--- a/utils/api.ts
+++ b/utils/api.ts
@@ -71,9 +71,18 @@ export const generateChapter = async ({ bookId, bookType, summary, title, chapte
 };
 
 export const loadChatState = async (bookId) => {
+    const cached = localStorage.getItem(`chat_${bookId}`);
+    if (cached) {
+        try {
+            return JSON.parse(cached);
+        } catch {}
+    }
     const res = await fetch(createUrl(`/api/book/chat?bookId=${bookId}`));
     if (res.ok) {
         const data = await res.json();
+        if (data.data) {
+            localStorage.setItem(`chat_${bookId}`, JSON.stringify(data.data));
+        }
         return data.data;
     } else {
         throw new Error('Failed to load chat');
@@ -81,6 +90,7 @@ export const loadChatState = async (bookId) => {
 };
 
 export const saveChatState = async (bookId, state) => {
+    localStorage.setItem(`chat_${bookId}`, JSON.stringify(state));
     const res = await fetch(new Request(createUrl('/api/book/chat'), {
         method: 'PUT',
         body: JSON.stringify({ bookId, state }),


### PR DESCRIPTION
## Summary
- restore outline message only if user is still on outline step
- cache chat state in local storage for quicker load

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6863e4fb24bc8324ab6dcc9d67ea1ac4