### PR TITLE
Improve summary step to show refined summary

### DIFF
--- a/components/ChatScreen.jsx
+++ b/components/ChatScreen.jsx
@@ -292,6 +292,10 @@ export default function ChatScreen({ initialBookId = null }) {
         const newBookId = created._id;
         setBookId(newBookId);
 
+        const refined = await askQuestion(
+          `Rewrite the following book summary in a single polished paragraph:\n${currentInput}`
+        );
+
         const answer = await askQuestion(
           `Provide 10 book title suggestions with subtitles based on the following summary:\n${currentInput}`
         );
@@ -309,7 +313,9 @@ export default function ChatScreen({ initialBookId = null }) {
                   sender: 'bot',
                   custom: (
                     <div>
-                      <p>Great! Based on your summary, here are some title ideas:</p>
+                      <p>
+                        Great! {refined} Based on your summary, here are some title ideas:
+                      </p>
                       <ul className="list-unstyled d-flex flex-wrap gap-2">
                         {titles.map((t, idx) => (
                           <li key={idx}>


### PR DESCRIPTION
## Summary
- update summary step in ChatScreen to call AI for a refined version of the user summary
- display refined summary in response before listing title ideas

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6864367eef6c8324b96b3dfe3483e901