### PR TITLE
Add simple key point input option

### DIFF
--- a/stylesheets/style.css
+++ b/stylesheets/style.css
@@ -108,6 +108,14 @@
     border-radius: 100px;
     font-size: 16px;
 }
+
+.btn-toggle-input{
+    background-color: transparent;
+    border: none;
+    color: #0f01ff;
+    cursor: pointer;
+    padding: 0.6rem 1rem;
+}
 .messages{
     width: 80%;
     margin-right: auto;


### PR DESCRIPTION
## Summary
- allow switching to a simple text box for key points
- parse semicolon-separated key points in `sendMessage`
- reset simple input flag when appropriate
- style the new button

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68643a3d678883248e0abf4b6d955d0a