### PR TITLE
Fix sendMessage handlers

### DIFF
--- a/components/ChatScreen.jsx
+++ b/components/ChatScreen.jsx
@@ -861,7 +861,7 @@ const generateAndUseOutline = async () => {
               onKeyDown={(e) => e.key === 'Enter' && sendMessage()}
               rows={1}
             />
-            <button className="btn-chat" onClick={sendMessage}>
+            <button className="btn-chat" onClick={() => sendMessage()}>
               <Icon icon="fa:send-o" />
             </button>
           </div>
@@ -901,7 +901,7 @@ const generateAndUseOutline = async () => {
                     onKeyDown={(e) => e.key === 'Enter' && sendMessage()}
                     rows={1}
                   />
-                  <button className="btn-chat" onClick={sendMessage}>
+                  <button className="btn-chat" onClick={() => sendMessage()}>
                     <Icon icon="fa:send-o" />
                   </button>
                 </div>
@@ -946,7 +946,7 @@ const generateAndUseOutline = async () => {
                     onKeyDown={(e) => e.key === 'Enter' && sendMessage()}
                     rows={1}
                   />
-                  <button className="btn-chat" onClick={sendMessage}>
+                  <button className="btn-chat" onClick={() => sendMessage()}>
                     <Icon icon="fa:send-o" />
                   </button>
                 </div>


### PR DESCRIPTION
## Summary
- ensure `sendMessage` isn't called with the click event

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68645d75b84c83249556169d29dbbe6a