### PR TITLE
Fix ChatScreen cleanup

### DIFF
--- a/components/ChatScreen.jsx
+++ b/components/ChatScreen.jsx
@@ -31,7 +31,6 @@ export default function ChatScreen({ initialBookId = null }) {
   const [refinedSummary, setRefinedSummary] = useState('');
   const [summary, setSummary] = useState('');
   const [currentChapter, setCurrentChapter] = useState(1);
-  const [chapterTitleOptions, setChapterTitleOptions] = useState([]);
   const [hasKeyPoints, setHasKeyPoints] = useState(false);
   const [isGenerating, setIsGenerating] = useState(false);
   const [isMultiline, setIsMultiline] = useState(false);
@@ -543,7 +542,6 @@ const getRequiredKeyPoints = () => {
       setKeyPoints(getInitialKeyPoints());
       setStep('keypoints');
       setUseSimpleInput(false);
-      setUseSimpleInput(false);
     } else {
       
       // const count = parseInt(chapterCount);
@@ -749,7 +747,6 @@ const getRequiredKeyPoints = () => {
     setSummary('');
     setRefinedSummary('');
     setTitleOptions([]);
-    setChapterTitleOptions([]);
     setCurrentChapter(1);
     setOutline([]);
     setHasKeyPoints(false);


### PR DESCRIPTION
## Summary
- remove leftover chapterTitleOptions state
- remove duplicate setUseSimpleInput calls

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6864ec3842748324bf0a1584305eb443