### PR TITLE
Fix markdown heading outline parsing

### DIFF
--- a/components/ChatScreen.jsx
+++ b/components/ChatScreen.jsx
@@ -576,7 +576,7 @@ const getRequiredKeyPoints = () => {
     let current = null;
 
     const isChapterLine = (l) => {
-      const cleaned = l.replace(/^[-*\s]+/, '').toLowerCase();
+      const cleaned = l.replace(/^[-*#\s]+/, '').toLowerCase();
       return /^(?:chapter\s*\d+|\d+)/.test(cleaned);
     };
 


### PR DESCRIPTION
## Summary
- handle `###` style markdown headings when parsing outlines

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864f3868c808324920eef483cddf1db