### PR TITLE
Improve chapter formatting

### DIFF
--- a/components/ChatScreen.jsx
+++ b/components/ChatScreen.jsx
@@ -765,7 +765,12 @@ const getRequiredKeyPoints = () => {
     if (!text || typeof text !== 'string') return text;
 
     // Remove Markdown-style bold markers
-    const sanitized = text.replace(/\*\*/g, '');
+    let sanitized = text.replace(/\*\*/g, '');
+
+    // Ensure chapter and part headings each start on a new line
+    sanitized = sanitized
+      .replace(/(?<!\n)(Chapter\s*\d+[^\n]*)/gi, '\n$1\n')
+      .replace(/(?<!\n)(Part\s*\d+[^\n]*)/gi, '\n$1\n');
 
     // Match lines that start with "1. ", "2. ", etc.
     const numberedListRegex = /^(\d+\.\s.*)$/gm;


### PR DESCRIPTION
## Summary
- improve `formatMessageText` so chapter and part headings show on their own lines

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865067aab7883248b116a0c4ce31521