### PR TITLE
Fix regex for formatting numbered lists

### DIFF
--- a/components/ChatScreen.jsx
+++ b/components/ChatScreen.jsx
@@ -796,11 +796,12 @@ sanitized = sanitized.replace(/\n{3,}/g, '\n\n').trim();
     // Match lines that start with "1. ", "2. ", etc.
     const numberedListRegex = /^(\d+\.\s.*)$/gm;
     const parts = sanitized.split(numberedListRegex);
+    const isNumberedItem = /^\d+\.\s.*$/;
 
     return (
       <>
         {parts.map((part, idx) =>
-          numberedListRegex.test(part) ? (
+          isNumberedItem.test(part.trim()) ? (
             <React.Fragment key={idx}>
               {part}
               <br />


### PR DESCRIPTION
## Summary
- fix regex use in `formatMessageText` so numbered list items render properly

## Testing
- `npm run lint`
- `npm run build` *(fails: Please define the MONGODB_URI environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_686528c76e00832493507f8aa780a2e6