### PR TITLE
Improve chapter & part formatting

### DIFF
--- a/components/ChatScreen.jsx
+++ b/components/ChatScreen.jsx
@@ -766,20 +766,18 @@ const getRequiredKeyPoints = () => {
    // Remove Markdown-style bold markers and stray hash symbols
 let sanitized = text.replace(/\*\*/g, '').replace(/#/g, '');
 
-// Normalize spacing for chapter and part headers like "Part2" → "Part 2"
+// Normalize spacing for chapter and part headers like "Part2" or "Part-2" → "Part 2"
 sanitized = sanitized
-  .replace(/(Chapter)\s*(\d+)/gi, '$1 $2')
-  .replace(/(Part)\s*(\d+)/gi, '$1 $2');
+  .replace(/(Chapter)\s*[-:]?\s*(\d+)/gi, '$1 $2')
+  .replace(/(Part)\s*[-:]?\s*(\d+)/gi, '$1 $2');
 
-// ✅ Fix Chapter titles: Put the whole "Chapter X: Title" on its own line
+// Put chapter and part titles on their own line for reliable detection
 sanitized = sanitized.replace(
-  /(Chapter\s*\d+\s*:\s*(?:[^\s]+\s*){1,5})/g,
+  /(Chapter\s*\d+\s*(?:[:\-])?\s*[^\n]+)/gi,
   '\n$1\n'
 );
-
-// ✅ Fix Part titles: Put the whole "Part X: Title" on its own line
 sanitized = sanitized.replace(
-  /(Part\s*\d+\s*:\s*(?:[^\s]+\s*){1,5})/g,
+  /(Part\s*\d+\s*(?:[:\-])?\s*[^\n]+)/gi,
   '\n$1\n'
 );
 

--- a/src/app/api/book/chapter/route.ts
+++ b/src/app/api/book/chapter/route.ts
@@ -24,7 +24,11 @@ export const POST = async (req: Request) => {
   const wordsPerPart =
     bookType === "Ebook" ? 700 : bookType === "Short Book" ? 1000 : 1500;
 
-  const prompt = `You are a professional book writer. Write chapter ${chapterIndex} titled "${chapterTitle}" for the ${bookType} "${title}". Divide the chapter into 4 parts, each exactly ${wordsPerPart} words. Each part must begin with a short title (for example, \"Part 1: Title\"). Base it on the following summary and key points.\nSummary: ${summary}\nKey points: ${keyPoints.join("; ")}`;
+  const prompt = `You are a professional book writer. Write chapter ${chapterIndex} titled "${chapterTitle}" for the ${bookType} "${title}".\n` +
+    `Start the chapter with \"Chapter ${chapterIndex}: ${chapterTitle}\" on its own line. ` +
+    `Divide the chapter into 4 parts, each exactly ${wordsPerPart} words. ` +
+    `Each part must begin on a new line with a heading in the format \"Part X: Title\".` +
+    ` Use the following summary and key points.\nSummary: ${summary}\nKey points: ${keyPoints.join("; ")}`;
 
   const encoder = new TextEncoder();
   let content = "";


### PR DESCRIPTION
## Summary
- refine chapter-generation prompt to start titles on their own lines
- handle more chapter and part title variations in the UI

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68652a397a508324bb378bc0ff8b0ecd