### PR TITLE
Add user detail screen

### DIFF
--- a/src/app/page.js
+++ b/src/app/page.js
@@ -1,6 +1,6 @@
 'use client'; // needed for state in Next.js 13+ app directory
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import styles from "./page.module.css";
 import { Icon } from "@iconify/react";
 import Link from "next/link";
@@ -13,6 +13,14 @@ export default function Home() {
   const [uuid, setUuid] = useState("");
   const [error, setError] = useState("");
   const router = useRouter();
+
+  useEffect(() => {
+    const name = localStorage.getItem('userName');
+    const email = localStorage.getItem('userEmail');
+    if (!name || !email) {
+      router.replace('/userDetail');
+    }
+  }, [router]);
 
   const handleContinue = async () => {
     setError("");

--- a/src/app/userDetail/page.jsx
+++ b/src/app/userDetail/page.jsx
@@ -1,0 +1,50 @@
+'use client';
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import styles from '../page.module.css';
+
+export default function UserDetail() {
+  const router = useRouter();
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+
+  useEffect(() => {
+    const storedName = localStorage.getItem('userName');
+    const storedEmail = localStorage.getItem('userEmail');
+    if (storedName && storedEmail) {
+      router.replace('/');
+    }
+  }, [router]);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (!name || !email) return;
+    localStorage.setItem('userName', name);
+    localStorage.setItem('userEmail', email);
+    router.push('/');
+  };
+
+  return (
+    <div className={styles.page}>
+      <main className={styles.main}>
+        <input
+          className={styles.oldBookInput}
+          type="text"
+          placeholder="Your Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <input
+          className={styles.oldBookInput}
+          type="email"
+          placeholder="Your Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <button className={styles.secondary} onClick={handleSubmit}>
+          Continue
+        </button>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add new `/userDetail` page for collecting user name and email
- store user information in localStorage and redirect to home afterwards
- check local storage on the homepage and send new visitors to `/userDetail`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68658397799c8324adbb481380f60f8c