### PR TITLE
Add user and author support with sheets endpoint

### DIFF
--- a/components/ChatScreen.jsx
+++ b/components/ChatScreen.jsx
@@ -316,7 +316,8 @@ export default function ChatScreen({ initialBookId = null }) {
 
       try {
 
-        const created = await createBook(currentInput);
+        const userId = localStorage.getItem('userId') || null;
+        const created = await createBook(currentInput, userId);
         const newBookId = created._id;
         setBookId(newBookId);
 

--- a/models/book.ts
+++ b/models/book.ts
@@ -14,7 +14,8 @@ const ChapterSchema = new mongoose.Schema({
 const BookSchema = new mongoose.Schema({
   summary: String,
   suggestedTitle: String,
-  status: { 
+  author: { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null },
+  status: {
     type: String, 
     enum: ['draft', 'generating', 'generated', 'published'],
     lowercase: true

--- a/models/user.ts
+++ b/models/user.ts
@@ -1,0 +1,10 @@
+import mongoose from 'mongoose'
+
+const UserSchema = new mongoose.Schema({
+  name: { type: String, required: true },
+  email: { type: String, required: true, lowercase: true }
+}, {
+  timestamps: true
+});
+
+export const User = mongoose.models.User || mongoose.model('User', UserSchema);

--- a/src/app/api/book/summary/route.ts
+++ b/src/app/api/book/summary/route.ts
@@ -4,12 +4,14 @@ import { connectToDatabase } from "../../../../../utils/db";
 import { Book } from "../../../../../models/book";
 
 export const POST = async (req: Request) => {
-    const { summary } = await req.json();
+    const { summary, authorId } = await req.json();
     if (!summary) {
         return NextResponse.json({ error: "Summary is required" }, { status: 400 });
     }
 
     await connectToDatabase();
-    const book = await Book.create({ summary, status: 'draft' });
+    const data: any = { summary, status: 'draft' };
+    if (authorId) data.author = authorId;
+    const book = await Book.create(data);
     return NextResponse.json({ data: book });
 };

--- a/src/app/api/sheets/route.ts
+++ b/src/app/api/sheets/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import { connectToDatabase } from "../../../../utils/db";
+import { Book } from "../../../../models/book";
+
+export const GET = async () => {
+  await connectToDatabase();
+  const books = await Book.find({ author: { $ne: null } })
+    .populate('author')
+    .lean();
+
+  const data = books.map((b: any) => ({
+    title: b.suggestedTitle || '',
+    summary: b.summary || '',
+    name: b.author?.name || '',
+    email: b.author?.email || '',
+  }));
+
+  return NextResponse.json({ data });
+};

--- a/src/app/api/user/route.ts
+++ b/src/app/api/user/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+import { connectToDatabase } from "../../../../utils/db";
+import { User } from "../../../../models/user";
+
+export const POST = async (req: Request) => {
+  const { name, email } = await req.json();
+  if (!name || !email) {
+    return NextResponse.json({ error: "Missing name or email" }, { status: 400 });
+  }
+  await connectToDatabase();
+  const user = await User.create({ name, email });
+  return NextResponse.json({ data: user });
+};

--- a/src/app/userDetail/page.jsx
+++ b/src/app/userDetail/page.jsx
@@ -2,6 +2,7 @@
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import styles from '../page.module.css';
+import { createUser } from '../../../utils/api';
 
 export default function UserDetail() {
   const router = useRouter();
@@ -16,9 +17,15 @@ export default function UserDetail() {
     }
   }, [router]);
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
     if (!name || !email) return;
+    try {
+      const user = await createUser(name, email);
+      localStorage.setItem('userId', user._id);
+    } catch (err) {
+      console.error('Failed to save user', err);
+    }
     localStorage.setItem('userName', name);
     localStorage.setItem('userEmail', email);
     router.push('/');

--- a/utils/api.ts
+++ b/utils/api.ts
@@ -17,10 +17,10 @@ export const askQuestion = async (question) => {
 
 }
 
-export const createBook = async (summary) => {
+export const createBook = async (summary, authorId) => {
     const res = await fetch(new Request(createUrl('/api/book/summary'), {
         method: 'POST',
-        body: JSON.stringify({ summary }),
+        body: JSON.stringify({ summary, authorId }),
     }));
     if(res.ok) {
         const data = await res.json();
@@ -118,5 +118,28 @@ export const saveChatState = async (bookId, state) => {
         return data.data;
     } else {
         throw new Error('Failed to save chat');
+    }
+};
+
+export const createUser = async (name, email) => {
+    const res = await fetch(new Request(createUrl('/api/user'), {
+        method: 'POST',
+        body: JSON.stringify({ name, email }),
+    }));
+    if(res.ok){
+        const data = await res.json();
+        return data.data;
+    } else {
+        throw new Error('Failed to create user');
+    }
+};
+
+export const fetchSheets = async () => {
+    const res = await fetch(createUrl('/api/sheets'));
+    if(res.ok){
+        const data = await res.json();
+        return data.data;
+    } else {
+        throw new Error('Failed to load sheets');
     }
 };


### PR DESCRIPTION
## Summary
- add `User` mongoose model
- add author reference in `Book` model
- update `/api/book/summary` to accept `authorId`
- add `/api/user` and `/api/sheets` endpoints
- persist user info from `userDetail` page
- include author when creating a book from `ChatScreen`
- expose `createUser` and `fetchSheets` helpers

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6865877374c88324926d2089675ee378