### PR TITLE
Allow public access to sheets API

### DIFF
--- a/src/app/api/sheets/route.ts
+++ b/src/app/api/sheets/route.ts
@@ -2,6 +2,10 @@ import { NextResponse } from "next/server";
 import { connectToDatabase } from "../../../../utils/db";
 import { Book } from "../../../../models/book";
 
+// Ensure this route always runs dynamically so it is accessible
+// without any client state such as localStorage.
+export const dynamic = "force-dynamic";
+
 export const GET = async () => {
   await connectToDatabase();
   const books = await Book.find({ author: { $ne: null } })


### PR DESCRIPTION
## Summary
- force dynamic mode in `/api/sheets` so the endpoint can be accessed without any client state

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6865a0203c608324acd18455169ed2f1