### PR TITLE
Fix chapter text formatting

### DIFF
--- a/utils/format.ts
+++ b/utils/format.ts
@@ -1,22 +1,24 @@
 export function formatChapterText(text: string): string {
-  if (!text || typeof text !== 'string') return text;
+  if (!text || typeof text !== "string") return text;
 
-  let sanitized = text.replace(/\*\*/g, '').replace(/#/g, '');
+  let sanitized = text.replace(/\*\*/g, "").replace(/#/g, "");
 
   // Standardise "Chapter X" and "Part X" spacing
   sanitized = sanitized
-    .replace(/(Chapter)\s*[-:]?\s*(\d+)/gi, '$1 $2')
-  .replace(/(Part)\s*[-:]?\s*(\d+)/gi, '$1 $2');
+    .replace(/(Chapter)\s*[-:]?\s*(\d+)/gi, "$1 $2")
+    .replace(/(Part)\s*[-:]?\s*(\d+)/gi, "$1 $2");
 
+  // Bold chapter titles and ensure they start on a new line
   sanitized = sanitized.replace(
-  /(Chapter\s*\d+\s*(?:[:\-])?\s*[^\n]+)/gi,
-    '\n$1\n'
+    /(Chapter\s*\d+\s*(?:[:\-])?\s*[^\n]+)/gi,
+    "\n**$1**\n"
   );
 
+  // Ensure each part heading begins on a new line
   sanitized = sanitized.replace(
-  /(Chapter\s*\d+\s*(?:[:\-])?\s*[^\n]+)/gi,
-  '\n$1\n'
+    /(Part\s*\d+\s*(?:[:\-])?\s*[^\n]+)/gi,
+    "\n$1\n"
   );
 
-  return sanitized;
+  return sanitized.trim();
 }


### PR DESCRIPTION
## Summary
- refine regex in `formatChapterText`
- bold chapter heading and put each part on its own line

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6866e7719c908324a54510a0cb99970b