### PR TITLE
Enable double spaces in chapter text

### DIFF
--- a/components/ChatScreen.jsx
+++ b/components/ChatScreen.jsx
@@ -721,10 +721,10 @@ const getRequiredKeyPoints = () => {
     }
 
   };
-  const formatMessageText = (text) => {
+  const formatMessageText = (text, doubleSpace = false) => {
     if (!text || typeof text !== 'string') return text;
 
-    const sanitized = formatChapterText(text);
+    const sanitized = formatChapterText(text, doubleSpace);
 
     // Match lines that start with "1. ", "2. ", etc.
     const numberedListRegex = /^(\d+\.\s.*)$/gm;

--- a/src/app/api/book/chapter/route.ts
+++ b/src/app/api/book/chapter/route.ts
@@ -80,7 +80,7 @@ export const POST = async (req: Request) => {
               controller.enqueue(encoder.encode("event: done\n\n"));
               controller.close();
 
-              const formatted = formatChapterText(content);
+              const formatted = formatChapterText(content, true);
 
               book.chapters.push({
                 idx: chapterIndex,


### PR DESCRIPTION
## Summary
- forward a `doubleSpace` flag when formatting messages
- store chapter text with double spaces

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686bccc229e48324bbfd81b2f695e5ff