### PR TITLE
Add skip option for keypoints

### DIFF
--- a/components/ChatScreen.jsx
+++ b/components/ChatScreen.jsx
@@ -715,6 +715,21 @@ const getRequiredKeyPoints = () => {
       setIsGenerating(false);
     };
 
+  const handleSkipKeyPoints = async () => {
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: generateId(),
+          sender: 'user',
+          text: 'Skip key points for this chapter',
+        },
+      ]);
+      setHasKeyPoints(false);
+      setIsGenerating(true);
+      await generateChapterContent(selectedChapter || input, []);
+      setIsGenerating(false);
+    };
+
 
   const handleClearChat = () => {
     setMessages([
@@ -895,6 +910,11 @@ const getRequiredKeyPoints = () => {
                     <Icon icon="fa:send-o" />
                   </button>
                 </div>
+                <div className="mt-2 text-end">
+                  <button className="btn-toggle-input" onClick={handleSkipKeyPoints}>
+                    Skip this step
+                  </button>
+                </div>
               </div>
             ) : (
               <div className="p-3 keypointBg">
@@ -918,9 +938,14 @@ const getRequiredKeyPoints = () => {
                   <button className="btn-chat" onClick={handleSubmitKeyPoints}>
                     Submit Key Points
                   </button>
-                  <button className="btn-toggle-input" onClick={() => setUseSimpleInput(true)}>
-                    Use simple input
-                  </button>
+                  <div className="d-flex gap-2">
+                    <button className="btn-toggle-input" onClick={() => setUseSimpleInput(true)}>
+                      Use simple input
+                    </button>
+                    <button className="btn-toggle-input" onClick={handleSkipKeyPoints}>
+                      Skip this step
+                    </button>
+                  </div>
                 </div>
               </div>
             )

--- a/src/app/api/book/chapter/route.ts
+++ b/src/app/api/book/chapter/route.ts
@@ -2,8 +2,8 @@ import { NextResponse } from "next/server";
 import { connectToDatabase } from "../../../../../utils/db";
 import { Book } from "../../../../../models/book";
 import { ChatOpenAI } from "@langchain/openai";
-import { CallbackManager } from "@langchain/core/callbacks/manager"; // ✅ Import this
-import { HumanMessage } from "@langchain/core/messages"; // ✅ Needed for .call()
+import { CallbackManager } from "@langchain/core/callbacks/manager";
+import { HumanMessage } from "@langchain/core/messages";
 import { formatChapterText } from "../../../../../utils/format";
 
 export const POST = async (req: Request) => {
@@ -24,44 +24,56 @@ export const POST = async (req: Request) => {
 
   const wordsPerPart =
     bookType === "Ebook" ? 700 : bookType === "Short Book" ? 1000 : 1500;
-    
-  
-  const prompt =
-  `You are a professional book writer. Write Chapter ${chapterIndex} titled "${chapterTitle}" for the ${bookType} "${title}".\n\n `+
 
-  // ── NEW STRICT WRITING INSTRUCTION ────────────────────────────────────────────
-  "STRICT WRITING INSTRUCTION PROMPT:\n" +
-  "When writing each chapter (and each part of the chapters), do not fabricate, fictionalize, or embellish anything.\n" +
-  "Do not invent any characters, events, stories, or situations.\n\n" +
-  "All content must be derived strictly and only from the key points provided. Your job is to expand and explain the key points in depth — using insight, reflection, analysis, or real-world application — but without introducing anything that was not directly included in the original key points.\n\n" +
-  "No added names. No imagined dialogue. No hypothetical scenarios. No “filler” stories.\n" +
-  "Stay 100% faithful to the key points provided.\n\n" +
-  "Write in a professional, clear, and sincere tone. This is non-fiction.\n\n" +
+  const basePrompt =
+    `You are a professional book writer. Write Chapter ${chapterIndex} titled "${chapterTitle}" for the ${bookType} "${title}".\n\n`;
 
-  // ── NEW FORMATTING REQUIREMENT ──────────────────────────────────────────────
-  "FORMATTING REQUIREMENT: In the chapter you produce, insert exactly two spaces after every period/full stop.\n\n" +
-
-  // ── EXISTING STRUCTURE RULES + KEY-POINT-DIVISION RULE ───────────────────────
-  "Strictly follow this structure:\n" +
-  "1. Start the chapter with this exact line (no extra characters, no quotes):\n" +
-  `   Chapter ${chapterIndex}: ${chapterTitle}\n` +
-  "2. Divide the chapter into exactly 4 parts. Each part must:\n" +
-  `   - Have MORE THAN ${wordsPerPart} WORDS.\n` +
-  "   - Begin on a new line\n" +
-  "   - Start with a heading in this exact format (including colon at the end):\n" +
-  "     Part X: Title:\n" +
-  "   (where X is 1, 2, 3, or 4)\n" +
-  "3. The COMPLETE chapter MUST have more than " + (wordsPerPart * 4) + " WORDS.\n" +
-  "4. Key-point usage:\n" +
-  "   - BEFORE writing, divide the provided key points into exactly 4 sequential groups (in the given order).\n" +
-  "   - Use ONLY the key points from Group 1 to write Part 1, Group 2 for Part 2, Group 3 for Part 3, and Group 4 for Part 4.\n" +
-  "   - Do NOT mix key points between parts.\n" +
-  "   - Do NOT introduce any content that is not explicitly present in the assigned key points.\n\n" +
-
-  // ── SOURCE MATERIAL PROVIDED TO THE MODEL ─────────────────────────────────────
-  "Use the following content to guide your writing:\n" +
-  `  Summary: ${summary}\n` +
-  `  Key points: ${keyPoints.join("; ")}\n`;
+  const prompt = keyPoints.length > 0
+    ? basePrompt +
+      "STRICT WRITING INSTRUCTION PROMPT:\n" +
+      "When writing each chapter (and each part of the chapters), do not fabricate, fictionalize, or embellish anything.\n" +
+      "Do not invent any characters, events, stories, or situations.\n\n" +
+      "All content must be derived strictly and only from the key points provided. Your job is to expand and explain the key points in depth — using insight, reflection, analysis, or real-world application — but without introducing anything that was not directly included in the original key points.\n\n" +
+      "No added names. No imagined dialogue. No hypothetical scenarios. No “filler” stories.\n" +
+      "Stay 100% faithful to the key points provided.\n\n" +
+      "Write in a professional, clear, and sincere tone. This is non-fiction.\n\n" +
+      "FORMATTING REQUIREMENT: In the chapter you produce, insert exactly two spaces after every period/full stop.\n\n" +
+      "Strictly follow this structure:\n" +
+      "1. Start the chapter with this exact line (no extra characters, no quotes):\n" +
+      `   Chapter ${chapterIndex}: ${chapterTitle}\n` +
+      "2. Divide the chapter into exactly 4 parts. Each part must:\n" +
+      `   - Have MORE THAN ${wordsPerPart} WORDS.\n` +
+      "   - Begin on a new line\n" +
+      "   - Start with a heading in this exact format (including colon at the end):\n" +
+      "     Part X: Title:\n" +
+      "   (where X is 1, 2, 3, or 4)\n" +
+      "3. The COMPLETE chapter MUST have more than " + (wordsPerPart * 4) + " WORDS.\n" +
+      "4. Key-point usage:\n" +
+      "   - BEFORE writing, divide the provided key points into exactly 4 sequential groups (in the given order).\n" +
+      "   - Use ONLY the key points from Group 1 to write Part 1, Group 2 for Part 2, Group 3 for Part 3, and Group 4 for Part 4.\n" +
+      "   - Do NOT mix key points between parts.\n" +
+      "   - Do NOT introduce any content that is not explicitly present in the assigned key points.\n\n" +
+      "Use the following content to guide your writing:\n" +
+      `  Summary: ${summary}\n` +
+      `  Key points: ${keyPoints.join("; ")}\n`
+    : basePrompt +
+      "STRICT WRITING INSTRUCTION PROMPT:\n" +
+      "When writing each chapter (and each part of the chapters), do not fabricate, fictionalize, or embellish anything.\n" +
+      "Do not invent any characters, events, stories, or situations.\n\n" +
+      "Write in a professional, clear, and sincere tone. This is non-fiction.\n\n" +
+      "FORMATTING REQUIREMENT: In the chapter you produce, insert exactly two spaces after every period/full stop.\n\n" +
+      "Strictly follow this structure:\n" +
+      "1. Start the chapter with this exact line (no extra characters, no quotes):\n" +
+      `   Chapter ${chapterIndex}: ${chapterTitle}\n` +
+      "2. Divide the chapter into exactly 4 parts. Each part must:\n" +
+      `   - Have MORE THAN ${wordsPerPart} WORDS.\n` +
+      "   - Begin on a new line\n" +
+      "   - Start with a heading in this exact format (including colon at the end):\n" +
+      "     Part X: Title:\n" +
+      "   (where X is 1, 2, 3, or 4)\n" +
+      "3. The COMPLETE chapter MUST have more than " + (wordsPerPart * 4) + " WORDS.\n\n" +
+      "Use the following content to guide your writing:\n" +
+      `  Summary: ${summary}\n`;
 
   const encoder = new TextEncoder();
   let content = "";
@@ -82,9 +94,6 @@ export const POST = async (req: Request) => {
             async handleLLMEnd() {
               controller.enqueue(encoder.encode("event: done\n\n"));
               controller.close();
-
-
-              
 
               const formatted = formatChapterText(content, true);
 
@@ -107,7 +116,6 @@ export const POST = async (req: Request) => {
           }),
         });
 
-        // ✅ Correct way to call the model
         await model.call([new HumanMessage(prompt)]);
       } catch (err) {
         controller.error(err);


### PR DESCRIPTION
## Summary
- allow skipping key point entry in chat screen
- generate chapters without key points when skipped

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686e502604688324a040c610b81591d9